### PR TITLE
check outfile exists

### DIFF
--- a/torrentfile/cli.py
+++ b/torrentfile/cli.py
@@ -343,6 +343,15 @@ def execute(args: list = None) -> list:
         help="path to write torrent file",
     )
 
+
+    create_parser.add_argument(
+        "--ow",
+        "--overwrite",
+        action="store_true",
+        dest="overwrite",
+        help="overwrite output file if it already exists",
+    )
+
     create_parser.add_argument(
         "--prog",
         "--progress",

--- a/torrentfile/commands.py
+++ b/torrentfile/commands.py
@@ -158,6 +158,19 @@ def create(args: Namespace) -> Namespace:
         object containing the path to created metafile and its contents.
     """
     kwargs = vars(args)
+
+    parent, name = os.path.split(kwargs.get('content'))
+    if not name:
+        name = os.path.basename(parent)
+    outfile = kwargs.get('outfile')
+    if not outfile:
+        path = os.path.join(os.getcwd(), name) + ".torrent"
+        outfile = path
+    if str(outfile)[-1] in "\\/":
+        outfile = outfile + (name + ".torrent")
+    if Path(outfile).exists() and not args.overwrite:
+        raise FileExistsError(outfile)
+
     if args.config:
         path = find_config_file(args)
         parse_config_file(path, kwargs)  # pragma: nocover


### PR DESCRIPTION
I copied the outfile determining code from class `MetaFile`, because it happens in func `write()`, and by that time files are already hashed, if it aborts then the hashing effort is wasted.