### PR TITLE
Editing public torrents

### DIFF
--- a/torrentfile/cli.py
+++ b/torrentfile/cli.py
@@ -472,6 +472,13 @@ def execute(args: List[str] = None) -> List[str]:
     )
 
     edit_parser.add_argument(
+        "--public",
+        action="store_true",
+        help="make torrent public",
+        dest="public",
+    )
+
+    edit_parser.add_argument(
         "--comment",
         help="replaces any existing comment with <comment>",
         metavar="<comment>",

--- a/torrentfile/commands.py
+++ b/torrentfile/commands.py
@@ -270,6 +270,7 @@ def edit(args: Namespace) -> str:
         "announce": args.announce,
         "source": args.source,
         "private": args.private,
+        "public": args.public,
         "comment": args.comment,
     }
     return edit_torrent(metafile, editargs)

--- a/torrentfile/edit.py
+++ b/torrentfile/edit.py
@@ -92,6 +92,9 @@ def edit_torrent(metafile: str, args: dict) -> dict:
     if args.get("private"):
         info["private"] = 1
 
+    if args.get("public"):
+        info.pop("private", None)
+
     if "announce" in args:
         val = args.get("announce", None)
         if isinstance(val, str):

--- a/torrentfile/edit.py
+++ b/torrentfile/edit.py
@@ -93,7 +93,9 @@ def edit_torrent(metafile: str, args: dict) -> dict:
         info["private"] = 1
 
     if args.get("public"):
-        info.pop("private", None)
+        if info.pop("private", None):
+            meta.pop("announce", None)
+            meta.pop("announce-list", None)
 
     if "announce" in args:
         val = args.get("announce", None)

--- a/torrentfile/edit.py
+++ b/torrentfile/edit.py
@@ -89,8 +89,8 @@ def edit_torrent(metafile: str, args: dict) -> dict:
     if "source" in args:
         info["source"] = args["source"]
 
-    if "private" in args:
-        info["private"] = int(args["private"])
+    if args.get("private"):
+        info["private"] = 1
 
     if "announce" in args:
         val = args.get("announce", None)


### PR DESCRIPTION
1. Prevent adding private=0
Public torrents don't have this field at all by default, adding it (even without changing to private) will change the info hash.
`args` is always populated with the keys, so even without doing anything related, the editing will always result in chaning of info hash, because of the additional private flag.
2. Add option to make private torrent public
This changes info hash so no worries of leaking?
Maybe the announce list should be automatically cleared?